### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = ""

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ To do
 - [X] Icons
 - [X] Orientation
 
+[![Run on Repl.it](https://repl.it/badge/github/kallyas/markdownEditor)](https://repl.it/github/kallyas/markdownEditor)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).